### PR TITLE
Removing a print message that is workable only for Python 2.x.y

### DIFF
--- a/db/__init__.py
+++ b/db/__init__.py
@@ -66,7 +66,6 @@ def from_env(var=None, db_name=None):
             var = env_name.upper() + "_" + var_name
         except KeyError:
             var = var_name
-    print "var", var
     url = os.environ[var]
     return from_url(url, db_name=db_name)
 


### PR DESCRIPTION
Removing a print message that is workable only for Python 2.x.y

This print message is available for Python 2.7 or older versions...!